### PR TITLE
Removing io_utils. prefix

### DIFF
--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -664,7 +664,7 @@ def build_aromaticity_dataset():
 
 
 def gen_train_plt_name(args):
-    return "results/" + io_utils.gen_prefix(args) + ".png"
+    return "results/" + gen_prefix(args) + ".png"
 
 
 def log_assignment(assign_tensor, writer, epoch, batch_idx):


### PR DESCRIPTION
The function is in the same module and hence the appropriate way to call it
would be to either drop io_utils. prefix or set PYTHONPATH to root directory
and call utils.io_utils.gen_prefix(). Addresses #17 