### PR TITLE
Write logs to directory specified by args.logdir

### DIFF
--- a/explainer/explain.py
+++ b/explainer/explain.py
@@ -1,6 +1,6 @@
 """ explain.py
 
-    Implementation of the explainer. 
+    Implementation of the explainer.
 """
 
 import math
@@ -69,7 +69,7 @@ class Explainer:
         self.writer = writer
         self.print_training = print_training
 
-    
+
     # Main method
     def explain(
         self, node_idx, graph_idx=0, graph_mode=False, unconstrained=False, model="exp"
@@ -90,7 +90,7 @@ class Explainer:
             )
             print("neigh graph idx: ", node_idx, node_idx_new)
             sub_label = np.expand_dims(sub_label, axis=0)
-        
+
         sub_adj = np.expand_dims(sub_adj, axis=0)
         sub_feat = np.expand_dims(sub_feat, axis=0)
 
@@ -227,7 +227,7 @@ class Explainer:
         Explain nodes
 
         Args:
-            - node_indices  :  Indices of the nodes to be explained 
+            - node_indices  :  Indices of the nodes to be explained
             - args          :  Program arguments (mainly for logging paths)
             - graph_idx     :  Index of the graph to explain the nodes from (if multiple).
         """
@@ -319,6 +319,7 @@ class Explainer:
                 G,
                 "graph/{}_{}_{}".format(self.args.dataset, model, i),
                 identify_self=True,
+                args=self.args
             )
 
         pred_all = np.concatenate((pred_all), axis=0)
@@ -374,6 +375,7 @@ class Explainer:
                 "graph/graphidx_{}_label={}".format(graph_idx, label),
                 identify_self=False,
                 nodecolor="feat",
+                args=self.args
             )
             masked_adjs.append(masked_adj)
 
@@ -391,6 +393,7 @@ class Explainer:
                 "graph/graphidx_{}".format(graph_idx),
                 identify_self=False,
                 nodecolor="feat",
+                args=self.args
             )
 
         # plot cmap for graphs' node features
@@ -500,7 +503,7 @@ class Explainer:
     def align(
         self, ref_feat, ref_adj, ref_node_idx, curr_feat, curr_adj, curr_node_idx, args
     ):
-        """ Tries to find an alignment between two graphs. 
+        """ Tries to find an alignment between two graphs.
         """
         ref_adj = torch.FloatTensor(ref_adj)
         curr_adj = torch.FloatTensor(curr_adj)

--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -80,7 +80,7 @@ def create_filename(save_dir, args, isbest=False, num_epochs=-1):
 
 def save_checkpoint(model, optimizer, args, num_epochs=-1, isbest=False, cg_dict=None):
     """Save pytorch model checkpoint.
-    
+
     Args:
         - model         : The PyTorch model to save.
         - optimizer     : The optimizer used to train the model.
@@ -348,13 +348,11 @@ def log_graph(
     fig.axes[0].xaxis.set_visible(False)
     fig.canvas.draw()
 
-    if args is None:
-        save_path = os.path.join("log/", name + ".pdf")
-    else:
-        save_path = os.path.join(
-            "log", name + gen_explainer_prefix(args) + "_" + str(epoch) + ".pdf"
-        )
-        print("log/" + name + gen_explainer_prefix(args) + "_" + str(epoch) + ".pdf")
+    logdir = "log" if not hasattr(args, "logdir") or not args.logdir else str(args.logdir)
+    if nodecolor != "feat":
+        name += gen_explainer_prefix(args)
+    save_path = os.path.join(logdir, name  + "_" + str(epoch) + ".pdf")
+    print(logdir + "/" + name + gen_explainer_prefix(args) + "_" + str(epoch) + ".pdf")
     os.makedirs(os.path.dirname(save_path), exist_ok=True)
     plt.savefig(save_path, format="pdf")
 
@@ -363,10 +361,10 @@ def log_graph(
 
 
 def plot_cmap(cmap, ncolor):
-    """ 
+    """
     A convenient function to plot colors of a matplotlib cmap
     Credit goes to http://gvallver.perso.univ-pau.fr/?p=712
- 
+
     Args:
         ncolor (int): number of color to show
         cmap: a cmap object or a matplotlib color name
@@ -653,7 +651,7 @@ def build_aromaticity_dataset():
             for j in range(nb_bonds):
                 if mol.GetBondWithIdx(j).GetIsAromatic():
                     aromatic_bonds.append(j)
-                    is_aromatic = True 
+                    is_aromatic = True
             moldict['aromaticity'] = is_aromatic
             moldict['aromatic_bonds'] = aromatic_bonds
             collector.append(moldict)


### PR DESCRIPTION
Currently, the log directory is created locally in the current working
directory. This patch introduces a change to specify a specific log
directory. If logdir does not exist, it fall back to the previous default
behavior.