### PR TITLE
typo: Fix a wrong filename in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ where `EXPERIMENT_NAME` is the experiment you want to replicate.
 For a complete list of options provided by the explainer:
 
 ```
-python train.py --help
+python explainer_main.py --help
 ```
 
 #### Visualizing the explanations


### PR DESCRIPTION
This line seems to be copy-and-pasted from above, but the filename remains unchanged.